### PR TITLE
UPG-4219: More version cleanup

### DIFF
--- a/config/go.mod
+++ b/config/go.mod
@@ -25,7 +25,7 @@ replace github.com/Enflick/aws-sdk-go-v2/service/ssooidc => ../service/ssooidc
 replace github.com/Enflick/aws-sdk-go-v2/service/sts => ../service/sts/
 
 require (
-	github.com/Enflick/aws-sdk-go-v2 v1.4.0
+	github.com/Enflick/aws-sdk-go-v2 v1.5.0
 	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3

--- a/config/go.mod
+++ b/config/go.mod
@@ -26,18 +26,18 @@ replace github.com/Enflick/aws-sdk-go-v2/service/sts => ../service/sts/
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.5.0
-	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 )

--- a/credentials/go.mod
+++ b/credentials/go.mod
@@ -4,18 +4,18 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 )
 
 replace github.com/Enflick/aws-sdk-go-v2 => ../

--- a/example/service/dynamodb/createTable/go.mod
+++ b/example/service/dynamodb/createTable/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.4.0
-	github.com/Enflick/aws-sdk-go-v2/config v1.27.16
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v1.32.6
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
 )
 
 require (
@@ -15,7 +15,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/example/service/dynamodb/createTable/go.mod
+++ b/example/service/dynamodb/createTable/go.mod
@@ -9,7 +9,7 @@ require (
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/credentials v1.17.16 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/example/service/dynamodb/createTable/go.mod
+++ b/example/service/dynamodb/createTable/go.mod
@@ -3,7 +3,7 @@ module github.com/Enflick/aws-sdk-go-v2/example/service/dynamodb/createTable
 go 1.20
 
 require (
-	github.com/Enflick/aws-sdk-go-v2 v1.4.0
+	github.com/Enflick/aws-sdk-go-v2 v1.5.0
 	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
 )

--- a/example/service/dynamodb/createTable/go.mod
+++ b/example/service/dynamodb/createTable/go.mod
@@ -4,22 +4,22 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.5.0
-	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325221836-b4195dfa2eb5
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/smithy-go v1.3.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )

--- a/example/service/dynamodb/createTable/go.mod
+++ b/example/service/dynamodb/createTable/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/example/service/dynamodb/scanItems/go.mod
+++ b/example/service/dynamodb/scanItems/go.mod
@@ -4,24 +4,24 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.5.0
-	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/feature/dynamodb/attributevalue v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/feature/dynamodb/attributevalue v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325221836-b4195dfa2eb5
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/smithy-go v1.3.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )

--- a/example/service/dynamodb/scanItems/go.mod
+++ b/example/service/dynamodb/scanItems/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.4.0
-	github.com/Enflick/aws-sdk-go-v2/config v1.27.16
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.13.20
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v1.32.6
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
 )
 
 require (
@@ -17,7 +17,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v1.20.8 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/example/service/dynamodb/scanItems/go.mod
+++ b/example/service/dynamodb/scanItems/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v1.20.8 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8 // indirect

--- a/example/service/dynamodb/scanItems/go.mod
+++ b/example/service/dynamodb/scanItems/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.4.0
 	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.13.20
+	github.com/Enflick/aws-sdk-go-v2/feature/dynamodb/attributevalue v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
 )
 
@@ -15,7 +15,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v1.20.8 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/example/service/dynamodb/scanItems/go.mod
+++ b/example/service/dynamodb/scanItems/go.mod
@@ -10,7 +10,7 @@ require (
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/credentials v1.17.16 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/example/service/dynamodb/scanItems/go.mod
+++ b/example/service/dynamodb/scanItems/go.mod
@@ -3,7 +3,7 @@ module github.com/Enflick/aws-sdk-go-v2/example/service/dynamodb/listItems
 go 1.20
 
 require (
-	github.com/Enflick/aws-sdk-go-v2 v1.4.0
+	github.com/Enflick/aws-sdk-go-v2 v1.5.0
 	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/feature/dynamodb/attributevalue v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3

--- a/example/service/s3/listObjects/go.mod
+++ b/example/service/s3/listObjects/go.mod
@@ -9,17 +9,17 @@ require (
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.4.0 // indirect
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 // indirect
-	github.com/Enflick/aws-sdk-go-v2/credentials v1.17.16 // indirect
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v1.3.9 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v1.17.7 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/example/service/s3/listObjects/go.mod
+++ b/example/service/s3/listObjects/go.mod
@@ -3,26 +3,26 @@ module github.com/Enflick/aws-sdk-go-v2/example/service/s3/listObjects
 go 1.20
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/service/s3 v1.54.3
 )
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.5.0 // indirect
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/smithy-go v1.3.0 // indirect
 )
 

--- a/example/service/s3/listObjects/go.mod
+++ b/example/service/s3/listObjects/go.mod
@@ -3,7 +3,7 @@ module github.com/Enflick/aws-sdk-go-v2/example/service/s3/listObjects
 go 1.20
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/config v1.27.16
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/s3 v1.54.3
 )
 

--- a/example/service/s3/listObjects/go.mod
+++ b/example/service/s3/listObjects/go.mod
@@ -8,7 +8,7 @@ require (
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2 v1.4.0 // indirect
+	github.com/Enflick/aws-sdk-go-v2 v1.5.0 // indirect
 	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/example/service/s3/listObjects/go.mod
+++ b/example/service/s3/listObjects/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v1.3.7 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v1.3.9 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/example/service/s3/usingPrivateLink/go.mod
+++ b/example/service/s3/usingPrivateLink/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.4.0
-	github.com/Enflick/aws-sdk-go-v2/config v1.27.16
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/s3 v1.54.3
 	github.com/Enflick/aws-sdk-go-v2/service/s3control v1.44.11
 )

--- a/example/service/s3/usingPrivateLink/go.mod
+++ b/example/service/s3/usingPrivateLink/go.mod
@@ -4,26 +4,26 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.5.0
-	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/service/s3 v1.54.3
 	github.com/Enflick/aws-sdk-go-v2/service/s3control v1.44.11
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/smithy-go v1.3.0 // indirect
 )
 

--- a/example/service/s3/usingPrivateLink/go.mod
+++ b/example/service/s3/usingPrivateLink/go.mod
@@ -3,7 +3,7 @@ module github.com/Enflick/aws-sdk-go-v2/example/service/s3/usingPrivateLink
 go 1.20
 
 require (
-	github.com/Enflick/aws-sdk-go-v2 v1.4.0
+	github.com/Enflick/aws-sdk-go-v2 v1.5.0
 	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/s3 v1.54.3
 	github.com/Enflick/aws-sdk-go-v2/service/s3control v1.44.11

--- a/example/service/s3/usingPrivateLink/go.mod
+++ b/example/service/s3/usingPrivateLink/go.mod
@@ -10,17 +10,17 @@ require (
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 // indirect
-	github.com/Enflick/aws-sdk-go-v2/credentials v1.17.16 // indirect
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v1.3.9 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v1.17.7 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/example/service/s3/usingPrivateLink/go.mod
+++ b/example/service/s3/usingPrivateLink/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v1.3.7 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v1.3.9 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/feature/dynamodb/attributevalue/go.mod
+++ b/feature/dynamodb/attributevalue/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v1.32.6
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v1.20.8
 )
 

--- a/feature/dynamodb/attributevalue/go.mod
+++ b/feature/dynamodb/attributevalue/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v0.0.0-20250325221836-b4195dfa2eb5
 )
 
 require (

--- a/feature/dynamodb/attributevalue/go.mod
+++ b/feature/dynamodb/attributevalue/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
 	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v1.20.8
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v0.0.0-20250325155711-0a4bf6fdbeb3
 )
 
 require (

--- a/feature/dynamodb/expression/go.mod
+++ b/feature/dynamodb/expression/go.mod
@@ -4,14 +4,14 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.13.20
+	github.com/Enflick/aws-sdk-go-v2/feature/dynamodb/attributevalue v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
 )
 
 require (
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v1.20.8 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/smithy-go v1.3.0 // indirect

--- a/feature/dynamodb/expression/go.mod
+++ b/feature/dynamodb/expression/go.mod
@@ -4,16 +4,16 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/feature/dynamodb/attributevalue v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/feature/dynamodb/attributevalue v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325221836-b4195dfa2eb5
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/smithy-go v1.3.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )

--- a/feature/dynamodb/expression/go.mod
+++ b/feature/dynamodb/expression/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
 	github.com/Enflick/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.13.20
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v1.32.6
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
 )
 
 require (
@@ -13,7 +13,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v1.20.8 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/smithy-go v1.3.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )

--- a/feature/dynamodbstreams/attributevalue/go.mod
+++ b/feature/dynamodbstreams/attributevalue/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v1.32.6
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v1.20.8
 )
 

--- a/feature/dynamodbstreams/attributevalue/go.mod
+++ b/feature/dynamodbstreams/attributevalue/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v0.0.0-20250325221836-b4195dfa2eb5
 )
 
 require (

--- a/feature/dynamodbstreams/attributevalue/go.mod
+++ b/feature/dynamodbstreams/attributevalue/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
 	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v1.20.8
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodbstreams v0.0.0-20250325155711-0a4bf6fdbeb3
 )
 
 require (

--- a/feature/ec2/imds/internal/configtesting/go.mod
+++ b/feature/ec2/imds/internal/configtesting/go.mod
@@ -3,21 +3,21 @@ module github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds/internal/configtesting
 go 1.20
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325221836-b4195dfa2eb5
 )
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.5.0 // indirect
-	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/smithy-go v1.3.0 // indirect
 )
 

--- a/feature/ec2/imds/internal/configtesting/go.mod
+++ b/feature/ec2/imds/internal/configtesting/go.mod
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.4.0 // indirect
-	github.com/Enflick/aws-sdk-go-v2/credentials v1.17.16 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/feature/ec2/imds/internal/configtesting/go.mod
+++ b/feature/ec2/imds/internal/configtesting/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/credentials v1.17.16 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/feature/ec2/imds/internal/configtesting/go.mod
+++ b/feature/ec2/imds/internal/configtesting/go.mod
@@ -8,7 +8,7 @@ require (
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2 v1.4.0 // indirect
+	github.com/Enflick/aws-sdk-go-v2 v1.5.0 // indirect
 	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/feature/ec2/imds/internal/configtesting/go.mod
+++ b/feature/ec2/imds/internal/configtesting/go.mod
@@ -3,7 +3,7 @@ module github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds/internal/configtesting
 go 1.20
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/config v1.27.16
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3
 )
 

--- a/feature/s3/manager/go.mod
+++ b/feature/s3/manager/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.4.0
-	github.com/Enflick/aws-sdk-go-v2/config v1.27.16
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/s3 v1.54.3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/feature/s3/manager/go.mod
+++ b/feature/s3/manager/go.mod
@@ -4,26 +4,26 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.5.0
-	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/service/s3 v1.54.3
 	github.com/Enflick/smithy-go v1.3.0
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )
 

--- a/feature/s3/manager/go.mod
+++ b/feature/s3/manager/go.mod
@@ -3,7 +3,7 @@ module github.com/Enflick/aws-sdk-go-v2/feature/s3/manager
 go 1.20
 
 require (
-	github.com/Enflick/aws-sdk-go-v2 v1.4.0
+	github.com/Enflick/aws-sdk-go-v2 v1.5.0
 	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/s3 v1.54.3
 	github.com/Enflick/smithy-go v1.3.0

--- a/feature/s3/manager/go.mod
+++ b/feature/s3/manager/go.mod
@@ -10,17 +10,17 @@ require (
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 // indirect
-	github.com/Enflick/aws-sdk-go-v2/credentials v1.17.16 // indirect
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v1.3.9 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v1.17.7 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/feature/s3/manager/go.mod
+++ b/feature/s3/manager/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v1.3.7 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v1.3.9 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/internal/configsources/configtesting/go.mod
+++ b/internal/configsources/configtesting/go.mod
@@ -3,7 +3,7 @@ module github.com/Enflick/aws-sdk-go-v2/internal/configsources/configtesting
 go 1.20
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/config v1.27.16
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 )
 

--- a/internal/configsources/configtesting/go.mod
+++ b/internal/configsources/configtesting/go.mod
@@ -3,21 +3,21 @@ module github.com/Enflick/aws-sdk-go-v2/internal/configsources/configtesting
 go 1.20
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 )
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.5.0 // indirect
-	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/smithy-go v1.3.0 // indirect
 )
 

--- a/internal/configsources/configtesting/go.mod
+++ b/internal/configsources/configtesting/go.mod
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.4.0 // indirect
-	github.com/Enflick/aws-sdk-go-v2/credentials v1.17.16 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/internal/configsources/configtesting/go.mod
+++ b/internal/configsources/configtesting/go.mod
@@ -8,7 +8,7 @@ require (
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2 v1.4.0 // indirect
+	github.com/Enflick/aws-sdk-go-v2 v1.5.0 // indirect
 	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/internal/configsources/configtesting/go.mod
+++ b/internal/configsources/configtesting/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/credentials v1.17.16 // indirect
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/internal/protocoltest/awsrestjson/go.mod
+++ b/internal/protocoltest/awsrestjson/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/internal/protocoltest/ec2query/go.mod
+++ b/internal/protocoltest/ec2query/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/internal/protocoltest/jsonrpc/go.mod
+++ b/internal/protocoltest/jsonrpc/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/internal/protocoltest/jsonrpc10/go.mod
+++ b/internal/protocoltest/jsonrpc10/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/internal/protocoltest/query/go.mod
+++ b/internal/protocoltest/query/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/internal/protocoltest/restxml/go.mod
+++ b/internal/protocoltest/restxml/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/internal/protocoltest/restxmlwithnamespace/go.mod
+++ b/internal/protocoltest/restxmlwithnamespace/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/internal/protocoltest/smithyrpcv2cbor/go.mod
+++ b/internal/protocoltest/smithyrpcv2cbor/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/accessanalyzer/go.mod
+++ b/service/accessanalyzer/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/account/go.mod
+++ b/service/account/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/acm/go.mod
+++ b/service/acm/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/acmpca/go.mod
+++ b/service/acmpca/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/amp/go.mod
+++ b/service/amp/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/amplify/go.mod
+++ b/service/amplify/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/amplifybackend/go.mod
+++ b/service/amplifybackend/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/amplifyuibuilder/go.mod
+++ b/service/amplifyuibuilder/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/apigateway/go.mod
+++ b/service/apigateway/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/apigatewaymanagementapi/go.mod
+++ b/service/apigatewaymanagementapi/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/apigatewayv2/go.mod
+++ b/service/apigatewayv2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/appconfig/go.mod
+++ b/service/appconfig/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/appconfigdata/go.mod
+++ b/service/appconfigdata/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/appfabric/go.mod
+++ b/service/appfabric/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/appflow/go.mod
+++ b/service/appflow/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/appintegrations/go.mod
+++ b/service/appintegrations/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/applicationautoscaling/go.mod
+++ b/service/applicationautoscaling/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/applicationcostprofiler/go.mod
+++ b/service/applicationcostprofiler/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/applicationdiscoveryservice/go.mod
+++ b/service/applicationdiscoveryservice/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/applicationinsights/go.mod
+++ b/service/applicationinsights/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/appmesh/go.mod
+++ b/service/appmesh/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/apprunner/go.mod
+++ b/service/apprunner/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/appstream/go.mod
+++ b/service/appstream/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/appsync/go.mod
+++ b/service/appsync/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/arczonalshift/go.mod
+++ b/service/arczonalshift/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/artifact/go.mod
+++ b/service/artifact/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/athena/go.mod
+++ b/service/athena/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/auditmanager/go.mod
+++ b/service/auditmanager/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/autoscaling/go.mod
+++ b/service/autoscaling/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/autoscalingplans/go.mod
+++ b/service/autoscalingplans/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/b2bi/go.mod
+++ b/service/b2bi/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/backup/go.mod
+++ b/service/backup/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/backupgateway/go.mod
+++ b/service/backupgateway/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/backupstorage/go.mod
+++ b/service/backupstorage/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/batch/go.mod
+++ b/service/batch/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/bcmdataexports/go.mod
+++ b/service/bcmdataexports/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/bedrock/go.mod
+++ b/service/bedrock/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/bedrockagent/go.mod
+++ b/service/bedrockagent/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/bedrockagentruntime/go.mod
+++ b/service/bedrockagentruntime/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0

--- a/service/bedrockagentruntime/go.mod
+++ b/service/bedrockagentruntime/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/bedrockruntime/go.mod
+++ b/service/bedrockruntime/go.mod
@@ -12,8 +12,8 @@ replace github.com/Enflick/aws-sdk-go-v2 => ../../
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/billingconductor/go.mod
+++ b/service/billingconductor/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/braket/go.mod
+++ b/service/braket/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/budgets/go.mod
+++ b/service/budgets/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/chatbot/go.mod
+++ b/service/chatbot/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/chime/go.mod
+++ b/service/chime/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/chimesdkidentity/go.mod
+++ b/service/chimesdkidentity/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/chimesdkmediapipelines/go.mod
+++ b/service/chimesdkmediapipelines/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/chimesdkmeetings/go.mod
+++ b/service/chimesdkmeetings/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/chimesdkmessaging/go.mod
+++ b/service/chimesdkmessaging/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/chimesdkvoice/go.mod
+++ b/service/chimesdkvoice/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cleanrooms/go.mod
+++ b/service/cleanrooms/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cleanroomsml/go.mod
+++ b/service/cleanroomsml/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cloud9/go.mod
+++ b/service/cloud9/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cloudcontrol/go.mod
+++ b/service/cloudcontrol/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/clouddirectory/go.mod
+++ b/service/clouddirectory/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cloudformation/go.mod
+++ b/service/cloudformation/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/cloudfront/go.mod
+++ b/service/cloudfront/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/cloudfrontkeyvaluestore/go.mod
+++ b/service/cloudfrontkeyvaluestore/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v1.3.7
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/cloudfrontkeyvaluestore/go.mod
+++ b/service/cloudfrontkeyvaluestore/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/cloudhsm/go.mod
+++ b/service/cloudhsm/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cloudhsmv2/go.mod
+++ b/service/cloudhsmv2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cloudsearch/go.mod
+++ b/service/cloudsearch/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cloudsearchdomain/go.mod
+++ b/service/cloudsearchdomain/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cloudtrail/go.mod
+++ b/service/cloudtrail/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cloudtraildata/go.mod
+++ b/service/cloudtraildata/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cloudwatch/go.mod
+++ b/service/cloudwatch/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/cloudwatchevents/go.mod
+++ b/service/cloudwatchevents/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cloudwatchlogs/go.mod
+++ b/service/cloudwatchlogs/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0

--- a/service/cloudwatchlogs/go.mod
+++ b/service/cloudwatchlogs/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/codeartifact/go.mod
+++ b/service/codeartifact/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/codebuild/go.mod
+++ b/service/codebuild/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/codecatalyst/go.mod
+++ b/service/codecatalyst/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/codecommit/go.mod
+++ b/service/codecommit/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/codeconnections/go.mod
+++ b/service/codeconnections/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/codedeploy/go.mod
+++ b/service/codedeploy/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/codeguruprofiler/go.mod
+++ b/service/codeguruprofiler/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/codegurureviewer/go.mod
+++ b/service/codegurureviewer/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/codegurusecurity/go.mod
+++ b/service/codegurusecurity/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/codepipeline/go.mod
+++ b/service/codepipeline/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/codestar/go.mod
+++ b/service/codestar/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/codestarconnections/go.mod
+++ b/service/codestarconnections/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/codestarnotifications/go.mod
+++ b/service/codestarnotifications/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cognitoidentity/go.mod
+++ b/service/cognitoidentity/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cognitoidentityprovider/go.mod
+++ b/service/cognitoidentityprovider/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/cognitosync/go.mod
+++ b/service/cognitosync/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/comprehend/go.mod
+++ b/service/comprehend/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/comprehendmedical/go.mod
+++ b/service/comprehendmedical/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/computeoptimizer/go.mod
+++ b/service/computeoptimizer/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/configservice/go.mod
+++ b/service/configservice/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/connect/go.mod
+++ b/service/connect/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/connectcampaigns/go.mod
+++ b/service/connectcampaigns/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/connectcases/go.mod
+++ b/service/connectcases/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/connectcontactlens/go.mod
+++ b/service/connectcontactlens/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/connectparticipant/go.mod
+++ b/service/connectparticipant/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/controlcatalog/go.mod
+++ b/service/controlcatalog/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/controltower/go.mod
+++ b/service/controltower/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/costandusagereportservice/go.mod
+++ b/service/costandusagereportservice/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/costexplorer/go.mod
+++ b/service/costexplorer/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/costoptimizationhub/go.mod
+++ b/service/costoptimizationhub/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/customerprofiles/go.mod
+++ b/service/customerprofiles/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/databasemigrationservice/go.mod
+++ b/service/databasemigrationservice/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/databrew/go.mod
+++ b/service/databrew/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/dataexchange/go.mod
+++ b/service/dataexchange/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/datapipeline/go.mod
+++ b/service/datapipeline/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/datasync/go.mod
+++ b/service/datasync/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/datazone/go.mod
+++ b/service/datazone/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/dax/go.mod
+++ b/service/dax/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/deadline/go.mod
+++ b/service/deadline/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/detective/go.mod
+++ b/service/detective/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/devicefarm/go.mod
+++ b/service/devicefarm/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/devopsguru/go.mod
+++ b/service/devopsguru/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/directconnect/go.mod
+++ b/service/directconnect/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/directoryservice/go.mod
+++ b/service/directoryservice/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/dlm/go.mod
+++ b/service/dlm/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/docdb/go.mod
+++ b/service/docdb/go.mod
@@ -4,10 +4,10 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0
 )

--- a/service/docdbelastic/go.mod
+++ b/service/docdbelastic/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/drs/go.mod
+++ b/service/drs/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/dynamodb/go.mod
+++ b/service/dynamodb/go.mod
@@ -4,10 +4,10 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0
 )

--- a/service/dynamodb/go.mod
+++ b/service/dynamodb/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0
 )

--- a/service/dynamodbstreams/go.mod
+++ b/service/dynamodbstreams/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/ebs/go.mod
+++ b/service/ebs/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/ec2/go.mod
+++ b/service/ec2/go.mod
@@ -4,10 +4,10 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0
 )

--- a/service/ec2instanceconnect/go.mod
+++ b/service/ec2instanceconnect/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/ecr/go.mod
+++ b/service/ecr/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/ecrpublic/go.mod
+++ b/service/ecrpublic/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/ecs/go.mod
+++ b/service/ecs/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/efs/go.mod
+++ b/service/efs/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/eks/go.mod
+++ b/service/eks/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/eksauth/go.mod
+++ b/service/eksauth/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/elasticache/go.mod
+++ b/service/elasticache/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/elasticbeanstalk/go.mod
+++ b/service/elasticbeanstalk/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/elasticinference/go.mod
+++ b/service/elasticinference/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/elasticloadbalancing/go.mod
+++ b/service/elasticloadbalancing/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/elasticloadbalancingv2/go.mod
+++ b/service/elasticloadbalancingv2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/elasticsearchservice/go.mod
+++ b/service/elasticsearchservice/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/elastictranscoder/go.mod
+++ b/service/elastictranscoder/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/emr/go.mod
+++ b/service/emr/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/emrcontainers/go.mod
+++ b/service/emrcontainers/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/emrserverless/go.mod
+++ b/service/emrserverless/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/entityresolution/go.mod
+++ b/service/entityresolution/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/eventbridge/go.mod
+++ b/service/eventbridge/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v1.3.7
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/eventbridge/go.mod
+++ b/service/eventbridge/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/evidently/go.mod
+++ b/service/evidently/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/finspace/go.mod
+++ b/service/finspace/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/finspacedata/go.mod
+++ b/service/finspacedata/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/firehose/go.mod
+++ b/service/firehose/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/fis/go.mod
+++ b/service/fis/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/fms/go.mod
+++ b/service/fms/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/forecast/go.mod
+++ b/service/forecast/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/forecastquery/go.mod
+++ b/service/forecastquery/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/frauddetector/go.mod
+++ b/service/frauddetector/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/freetier/go.mod
+++ b/service/freetier/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/fsx/go.mod
+++ b/service/fsx/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/gamelift/go.mod
+++ b/service/gamelift/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/glacier/go.mod
+++ b/service/glacier/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/globalaccelerator/go.mod
+++ b/service/globalaccelerator/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/glue/go.mod
+++ b/service/glue/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/grafana/go.mod
+++ b/service/grafana/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/greengrass/go.mod
+++ b/service/greengrass/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/greengrassv2/go.mod
+++ b/service/greengrassv2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/groundstation/go.mod
+++ b/service/groundstation/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/guardduty/go.mod
+++ b/service/guardduty/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/health/go.mod
+++ b/service/health/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/healthlake/go.mod
+++ b/service/healthlake/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iam/go.mod
+++ b/service/iam/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/identitystore/go.mod
+++ b/service/identitystore/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/imagebuilder/go.mod
+++ b/service/imagebuilder/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/inspector/go.mod
+++ b/service/inspector/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/inspector2/go.mod
+++ b/service/inspector2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/inspectorscan/go.mod
+++ b/service/inspectorscan/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/internal/benchmark/go.mod
+++ b/service/internal/benchmark/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v1.32.6
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/lexruntimeservice v1.20.8
 	github.com/Enflick/aws-sdk-go-v2/service/s3 v1.54.3
 	github.com/Enflick/aws-sdk-go-v2/service/schemas v1.24.8
@@ -19,7 +19,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/service/internal/benchmark/go.mod
+++ b/service/internal/benchmark/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v1.3.7 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v1.3.9 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8 // indirect

--- a/service/internal/benchmark/go.mod
+++ b/service/internal/benchmark/go.mod
@@ -13,15 +13,15 @@ require (
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 // indirect
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v1.3.9 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v1.17.7 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )
 

--- a/service/internal/benchmark/go.mod
+++ b/service/internal/benchmark/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/service/lexruntimeservice v1.20.8
 	github.com/Enflick/aws-sdk-go-v2/service/s3 v1.54.3
 	github.com/Enflick/aws-sdk-go-v2/service/schemas v1.24.8
@@ -13,15 +13,15 @@ require (
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )
 

--- a/service/internal/checksum/go.mod
+++ b/service/internal/checksum/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/internal/eventstreamtesting/go.mod
+++ b/service/internal/eventstreamtesting/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325221836-b4195dfa2eb5
 )
 
 require github.com/Enflick/smithy-go v1.3.0 // indirect

--- a/service/internal/eventstreamtesting/go.mod
+++ b/service/internal/eventstreamtesting/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2
-	github.com/Enflick/aws-sdk-go-v2/credentials v1.17.16
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3
 )
 
 require github.com/Enflick/smithy-go v1.3.0 // indirect

--- a/service/internal/integrationtest/go.mod
+++ b/service/internal/integrationtest/go.mod
@@ -1,7 +1,7 @@
 module github.com/Enflick/aws-sdk-go-v2/service/internal/integrationtest
 
 require (
-	github.com/Enflick/aws-sdk-go-v2 v1.4.0
+	github.com/Enflick/aws-sdk-go-v2 v1.5.0
 	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/feature/s3/manager v1.16.21
 	github.com/Enflick/aws-sdk-go-v2/service/acm v1.26.0

--- a/service/internal/integrationtest/go.mod
+++ b/service/internal/integrationtest/go.mod
@@ -2,7 +2,7 @@ module github.com/Enflick/aws-sdk-go-v2/service/internal/integrationtest
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.4.0
-	github.com/Enflick/aws-sdk-go-v2/config v1.27.16
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/feature/s3/manager v1.16.21
 	github.com/Enflick/aws-sdk-go-v2/service/acm v1.26.0
 	github.com/Enflick/aws-sdk-go-v2/service/apigateway v1.23.10
@@ -31,7 +31,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/service/directconnect v1.24.8
 	github.com/Enflick/aws-sdk-go-v2/service/directoryservice v1.24.8
 	github.com/Enflick/aws-sdk-go-v2/service/docdb v1.34.4
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v1.32.6
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/ec2 v1.162.0
 	github.com/Enflick/aws-sdk-go-v2/service/ecr v1.28.3
 	github.com/Enflick/aws-sdk-go-v2/service/ecs v1.41.11
@@ -99,7 +99,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/service/internal/integrationtest/go.mod
+++ b/service/internal/integrationtest/go.mod
@@ -95,8 +95,8 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v1.3.7 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v1.3.9 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8 // indirect

--- a/service/internal/integrationtest/go.mod
+++ b/service/internal/integrationtest/go.mod
@@ -90,18 +90,18 @@ require (
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 // indirect
-	github.com/Enflick/aws-sdk-go-v2/credentials v1.17.16 // indirect
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v1.3.9 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v1.17.7 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/service/internal/integrationtest/go.mod
+++ b/service/internal/integrationtest/go.mod
@@ -2,7 +2,7 @@ module github.com/Enflick/aws-sdk-go-v2/service/internal/integrationtest
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.5.0
-	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/feature/s3/manager v1.16.21
 	github.com/Enflick/aws-sdk-go-v2/service/acm v1.26.0
 	github.com/Enflick/aws-sdk-go-v2/service/apigateway v1.23.10
@@ -31,7 +31,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/service/directconnect v1.24.8
 	github.com/Enflick/aws-sdk-go-v2/service/directoryservice v1.24.8
 	github.com/Enflick/aws-sdk-go-v2/service/docdb v1.34.4
-	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/dynamodb v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/service/ec2 v1.162.0
 	github.com/Enflick/aws-sdk-go-v2/service/ecr v1.28.3
 	github.com/Enflick/aws-sdk-go-v2/service/ecs v1.41.11
@@ -78,7 +78,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/service/sns v1.29.8
 	github.com/Enflick/aws-sdk-go-v2/service/sqs v1.32.3
 	github.com/Enflick/aws-sdk-go-v2/service/ssm v1.50.4
-	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/service/support v1.22.4
 	github.com/Enflick/aws-sdk-go-v2/service/timestreamwrite v1.25.9
 	github.com/Enflick/aws-sdk-go-v2/service/transcribestreaming v1.17.8
@@ -90,20 +90,20 @@ require (
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )
 

--- a/service/internetmonitor/go.mod
+++ b/service/internetmonitor/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iot/go.mod
+++ b/service/iot/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iot1clickdevicesservice/go.mod
+++ b/service/iot1clickdevicesservice/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iot1clickprojects/go.mod
+++ b/service/iot1clickprojects/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iotanalytics/go.mod
+++ b/service/iotanalytics/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iotdataplane/go.mod
+++ b/service/iotdataplane/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iotdeviceadvisor/go.mod
+++ b/service/iotdeviceadvisor/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iotevents/go.mod
+++ b/service/iotevents/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/ioteventsdata/go.mod
+++ b/service/ioteventsdata/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iotfleethub/go.mod
+++ b/service/iotfleethub/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iotfleetwise/go.mod
+++ b/service/iotfleetwise/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iotjobsdataplane/go.mod
+++ b/service/iotjobsdataplane/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iotsecuretunneling/go.mod
+++ b/service/iotsecuretunneling/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iotsitewise/go.mod
+++ b/service/iotsitewise/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/iotthingsgraph/go.mod
+++ b/service/iotthingsgraph/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iottwinmaker/go.mod
+++ b/service/iottwinmaker/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/iotwireless/go.mod
+++ b/service/iotwireless/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/ivs/go.mod
+++ b/service/ivs/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/ivschat/go.mod
+++ b/service/ivschat/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/ivsrealtime/go.mod
+++ b/service/ivsrealtime/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/kafka/go.mod
+++ b/service/kafka/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/kafkaconnect/go.mod
+++ b/service/kafkaconnect/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/kendra/go.mod
+++ b/service/kendra/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/kendraranking/go.mod
+++ b/service/kendraranking/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/keyspaces/go.mod
+++ b/service/keyspaces/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/kinesis/go.mod
+++ b/service/kinesis/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0

--- a/service/kinesis/go.mod
+++ b/service/kinesis/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/kinesis/internal/testing/go.mod
+++ b/service/kinesis/internal/testing/go.mod
@@ -4,14 +4,14 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/internal/eventstreamtesting v1.4.3
 	github.com/Enflick/aws-sdk-go-v2/service/kinesis v1.27.8
 	github.com/Enflick/smithy-go v1.3.0
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/credentials v1.17.16 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/service/kinesis/internal/testing/go.mod
+++ b/service/kinesis/internal/testing/go.mod
@@ -4,15 +4,15 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/service/internal/eventstreamtesting v1.4.3
 	github.com/Enflick/aws-sdk-go-v2/service/kinesis v1.27.8
 	github.com/Enflick/smithy-go v1.3.0
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )

--- a/service/kinesisanalytics/go.mod
+++ b/service/kinesisanalytics/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/kinesisanalyticsv2/go.mod
+++ b/service/kinesisanalyticsv2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/kinesisvideo/go.mod
+++ b/service/kinesisvideo/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/kinesisvideoarchivedmedia/go.mod
+++ b/service/kinesisvideoarchivedmedia/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/kinesisvideomedia/go.mod
+++ b/service/kinesisvideomedia/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/kinesisvideosignaling/go.mod
+++ b/service/kinesisvideosignaling/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/kinesisvideowebrtcstorage/go.mod
+++ b/service/kinesisvideowebrtcstorage/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/kms/go.mod
+++ b/service/kms/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/lakeformation/go.mod
+++ b/service/lakeformation/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/lambda/go.mod
+++ b/service/lambda/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0

--- a/service/lambda/go.mod
+++ b/service/lambda/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/launchwizard/go.mod
+++ b/service/launchwizard/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/lexmodelbuildingservice/go.mod
+++ b/service/lexmodelbuildingservice/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/lexmodelsv2/go.mod
+++ b/service/lexmodelsv2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/lexruntimeservice/go.mod
+++ b/service/lexruntimeservice/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/lexruntimev2/go.mod
+++ b/service/lexruntimev2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0

--- a/service/lexruntimev2/go.mod
+++ b/service/lexruntimev2/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/licensemanager/go.mod
+++ b/service/licensemanager/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/licensemanagerlinuxsubscriptions/go.mod
+++ b/service/licensemanagerlinuxsubscriptions/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/licensemanagerusersubscriptions/go.mod
+++ b/service/licensemanagerusersubscriptions/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/lightsail/go.mod
+++ b/service/lightsail/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/location/go.mod
+++ b/service/location/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/lookoutequipment/go.mod
+++ b/service/lookoutequipment/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/lookoutmetrics/go.mod
+++ b/service/lookoutmetrics/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/lookoutvision/go.mod
+++ b/service/lookoutvision/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/m2/go.mod
+++ b/service/m2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/machinelearning/go.mod
+++ b/service/machinelearning/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/macie2/go.mod
+++ b/service/macie2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/mailmanager/go.mod
+++ b/service/mailmanager/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/managedblockchain/go.mod
+++ b/service/managedblockchain/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/managedblockchainquery/go.mod
+++ b/service/managedblockchainquery/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/marketplaceagreement/go.mod
+++ b/service/marketplaceagreement/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/marketplacecatalog/go.mod
+++ b/service/marketplacecatalog/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/marketplacecommerceanalytics/go.mod
+++ b/service/marketplacecommerceanalytics/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/marketplacedeployment/go.mod
+++ b/service/marketplacedeployment/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/marketplaceentitlementservice/go.mod
+++ b/service/marketplaceentitlementservice/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/marketplacemetering/go.mod
+++ b/service/marketplacemetering/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/mediaconnect/go.mod
+++ b/service/mediaconnect/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/mediaconvert/go.mod
+++ b/service/mediaconvert/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/medialive/go.mod
+++ b/service/medialive/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/mediapackage/go.mod
+++ b/service/mediapackage/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/mediapackagev2/go.mod
+++ b/service/mediapackagev2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/mediapackagevod/go.mod
+++ b/service/mediapackagevod/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/mediastore/go.mod
+++ b/service/mediastore/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/mediastoredata/go.mod
+++ b/service/mediastoredata/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/mediatailor/go.mod
+++ b/service/mediatailor/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/medicalimaging/go.mod
+++ b/service/medicalimaging/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/memorydb/go.mod
+++ b/service/memorydb/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/mgn/go.mod
+++ b/service/mgn/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/migrationhub/go.mod
+++ b/service/migrationhub/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/migrationhubconfig/go.mod
+++ b/service/migrationhubconfig/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/migrationhuborchestrator/go.mod
+++ b/service/migrationhuborchestrator/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/migrationhubrefactorspaces/go.mod
+++ b/service/migrationhubrefactorspaces/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/migrationhubstrategy/go.mod
+++ b/service/migrationhubstrategy/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/mobile/go.mod
+++ b/service/mobile/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/mq/go.mod
+++ b/service/mq/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/mturk/go.mod
+++ b/service/mturk/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/mwaa/go.mod
+++ b/service/mwaa/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/neptune/go.mod
+++ b/service/neptune/go.mod
@@ -4,10 +4,10 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0
 )

--- a/service/neptunedata/go.mod
+++ b/service/neptunedata/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/neptunegraph/go.mod
+++ b/service/neptunegraph/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/networkfirewall/go.mod
+++ b/service/networkfirewall/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/networkmanager/go.mod
+++ b/service/networkmanager/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/networkmonitor/go.mod
+++ b/service/networkmonitor/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/nimble/go.mod
+++ b/service/nimble/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/oam/go.mod
+++ b/service/oam/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/omics/go.mod
+++ b/service/omics/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/opensearch/go.mod
+++ b/service/opensearch/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/opensearchserverless/go.mod
+++ b/service/opensearchserverless/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/opsworks/go.mod
+++ b/service/opsworks/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/opsworkscm/go.mod
+++ b/service/opsworkscm/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/organizations/go.mod
+++ b/service/organizations/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/osis/go.mod
+++ b/service/osis/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/outposts/go.mod
+++ b/service/outposts/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/panorama/go.mod
+++ b/service/panorama/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/paymentcryptography/go.mod
+++ b/service/paymentcryptography/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/paymentcryptographydata/go.mod
+++ b/service/paymentcryptographydata/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/pcaconnectorad/go.mod
+++ b/service/pcaconnectorad/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/personalize/go.mod
+++ b/service/personalize/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/personalizeevents/go.mod
+++ b/service/personalizeevents/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/personalizeruntime/go.mod
+++ b/service/personalizeruntime/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/pi/go.mod
+++ b/service/pi/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/pinpoint/go.mod
+++ b/service/pinpoint/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/pinpointemail/go.mod
+++ b/service/pinpointemail/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/pinpointsmsvoice/go.mod
+++ b/service/pinpointsmsvoice/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/pinpointsmsvoicev2/go.mod
+++ b/service/pinpointsmsvoicev2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/pipes/go.mod
+++ b/service/pipes/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/polly/go.mod
+++ b/service/polly/go.mod
@@ -4,10 +4,10 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/pricing/go.mod
+++ b/service/pricing/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/privatenetworks/go.mod
+++ b/service/privatenetworks/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/proton/go.mod
+++ b/service/proton/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/qbusiness/go.mod
+++ b/service/qbusiness/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0

--- a/service/qbusiness/go.mod
+++ b/service/qbusiness/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/qconnect/go.mod
+++ b/service/qconnect/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/qldb/go.mod
+++ b/service/qldb/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/qldbsession/go.mod
+++ b/service/qldbsession/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/quicksight/go.mod
+++ b/service/quicksight/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/ram/go.mod
+++ b/service/ram/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/rbin/go.mod
+++ b/service/rbin/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/rds/go.mod
+++ b/service/rds/go.mod
@@ -4,10 +4,10 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0
 )

--- a/service/rdsdata/go.mod
+++ b/service/rdsdata/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/redshift/go.mod
+++ b/service/redshift/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/redshiftdata/go.mod
+++ b/service/redshiftdata/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/redshiftserverless/go.mod
+++ b/service/redshiftserverless/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/rekognition/go.mod
+++ b/service/rekognition/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/repostspace/go.mod
+++ b/service/repostspace/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/resiliencehub/go.mod
+++ b/service/resiliencehub/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/resourceexplorer2/go.mod
+++ b/service/resourceexplorer2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/resourcegroups/go.mod
+++ b/service/resourcegroups/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/resourcegroupstaggingapi/go.mod
+++ b/service/resourcegroupstaggingapi/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/robomaker/go.mod
+++ b/service/robomaker/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/rolesanywhere/go.mod
+++ b/service/rolesanywhere/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/route53/go.mod
+++ b/service/route53/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/route53domains/go.mod
+++ b/service/route53domains/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/route53profiles/go.mod
+++ b/service/route53profiles/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/route53recoverycluster/go.mod
+++ b/service/route53recoverycluster/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/route53recoverycontrolconfig/go.mod
+++ b/service/route53recoverycontrolconfig/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/route53recoveryreadiness/go.mod
+++ b/service/route53recoveryreadiness/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/route53resolver/go.mod
+++ b/service/route53resolver/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/rum/go.mod
+++ b/service/rum/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/s3/go.mod
+++ b/service/s3/go.mod
@@ -4,14 +4,14 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/s3/go.mod
+++ b/service/s3/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/v4a v1.3.7
+	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v1.3.9
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3

--- a/service/s3/go.mod
+++ b/service/s3/go.mod
@@ -4,14 +4,14 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/v4a v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v1.3.9
+	github.com/Enflick/aws-sdk-go-v2/service/internal/checksum v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v1.17.7
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/s3/internal/configtesting/go.mod
+++ b/service/s3/internal/configtesting/go.mod
@@ -3,7 +3,7 @@ module github.com/Enflick/aws-sdk-go-v2/service/s3/internal/configtesting
 go 1.20
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/config v1.27.16
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3
 )
 

--- a/service/s3/internal/configtesting/go.mod
+++ b/service/s3/internal/configtesting/go.mod
@@ -3,22 +3,22 @@ module github.com/Enflick/aws-sdk-go-v2/service/s3/internal/configtesting
 go 1.20
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/config v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325221836-b4195dfa2eb5
 )
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.5.0 // indirect
-	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/ssooidc v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/service/sts v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/smithy-go v1.3.0 // indirect
 )
 

--- a/service/s3/internal/configtesting/go.mod
+++ b/service/s3/internal/configtesting/go.mod
@@ -8,7 +8,7 @@ require (
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2 v1.4.0 // indirect
+	github.com/Enflick/aws-sdk-go-v2 v1.5.0 // indirect
 	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/service/s3/internal/configtesting/go.mod
+++ b/service/s3/internal/configtesting/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/ini v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/service/sso v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/service/s3/internal/configtesting/go.mod
+++ b/service/s3/internal/configtesting/go.mod
@@ -4,12 +4,12 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2/config v1.27.16
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v1.17.7
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3
 )
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.4.0 // indirect
-	github.com/Enflick/aws-sdk-go-v2/credentials v1.17.16 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/feature/ec2/imds v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect

--- a/service/s3control/go.mod
+++ b/service/s3control/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v1.17.7
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/s3control/go.mod
+++ b/service/s3control/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/internal/s3shared v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/s3outposts/go.mod
+++ b/service/s3outposts/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/sagemaker/go.mod
+++ b/service/sagemaker/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/sagemakera2iruntime/go.mod
+++ b/service/sagemakera2iruntime/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/sagemakeredge/go.mod
+++ b/service/sagemakeredge/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/sagemakerfeaturestoreruntime/go.mod
+++ b/service/sagemakerfeaturestoreruntime/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/sagemakergeospatial/go.mod
+++ b/service/sagemakergeospatial/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/sagemakermetrics/go.mod
+++ b/service/sagemakermetrics/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/sagemakerruntime/go.mod
+++ b/service/sagemakerruntime/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0

--- a/service/sagemakerruntime/go.mod
+++ b/service/sagemakerruntime/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/savingsplans/go.mod
+++ b/service/savingsplans/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/scheduler/go.mod
+++ b/service/scheduler/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/schemas/go.mod
+++ b/service/schemas/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/secretsmanager/go.mod
+++ b/service/secretsmanager/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/securityhub/go.mod
+++ b/service/securityhub/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/securitylake/go.mod
+++ b/service/securitylake/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/serverlessapplicationrepository/go.mod
+++ b/service/serverlessapplicationrepository/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/servicecatalog/go.mod
+++ b/service/servicecatalog/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/servicecatalogappregistry/go.mod
+++ b/service/servicecatalogappregistry/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/servicediscovery/go.mod
+++ b/service/servicediscovery/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/servicequotas/go.mod
+++ b/service/servicequotas/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/ses/go.mod
+++ b/service/ses/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/sesv2/go.mod
+++ b/service/sesv2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/sfn/go.mod
+++ b/service/sfn/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/shield/go.mod
+++ b/service/shield/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/signer/go.mod
+++ b/service/signer/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/simspaceweaver/go.mod
+++ b/service/simspaceweaver/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/sms/go.mod
+++ b/service/sms/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/snowball/go.mod
+++ b/service/snowball/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/snowdevicemanagement/go.mod
+++ b/service/snowdevicemanagement/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/sns/go.mod
+++ b/service/sns/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/sqs/go.mod
+++ b/service/sqs/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/ssm/go.mod
+++ b/service/ssm/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/ssmcontacts/go.mod
+++ b/service/ssmcontacts/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/ssmincidents/go.mod
+++ b/service/ssmincidents/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/ssmsap/go.mod
+++ b/service/ssmsap/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/sso/go.mod
+++ b/service/sso/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/ssoadmin/go.mod
+++ b/service/ssoadmin/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/ssooidc/go.mod
+++ b/service/ssooidc/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/storagegateway/go.mod
+++ b/service/storagegateway/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/sts/go.mod
+++ b/service/sts/go.mod
@@ -4,10 +4,10 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/internal/accept-encoding v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/service/internal/presigned-url v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/supplychain/go.mod
+++ b/service/supplychain/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/support/go.mod
+++ b/service/support/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/supportapp/go.mod
+++ b/service/supportapp/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/swf/go.mod
+++ b/service/swf/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/synthetics/go.mod
+++ b/service/synthetics/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/textract/go.mod
+++ b/service/textract/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/timestreaminfluxdb/go.mod
+++ b/service/timestreaminfluxdb/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/timestreamquery/go.mod
+++ b/service/timestreamquery/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/timestreamquery/go.mod
+++ b/service/timestreamquery/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/timestreamwrite/go.mod
+++ b/service/timestreamwrite/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/timestreamwrite/go.mod
+++ b/service/timestreamwrite/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/service/internal/endpoint-discovery v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/smithy-go v1.3.0
 )
 

--- a/service/tnb/go.mod
+++ b/service/tnb/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/transcribe/go.mod
+++ b/service/transcribe/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/transcribestreaming/go.mod
+++ b/service/transcribestreaming/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0

--- a/service/transcribestreaming/go.mod
+++ b/service/transcribestreaming/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/transcribestreaming/internal/testing/go.mod
+++ b/service/transcribestreaming/internal/testing/go.mod
@@ -4,14 +4,14 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/aws-sdk-go-v2/service/internal/eventstreamtesting v1.4.3
 	github.com/Enflick/aws-sdk-go-v2/service/transcribestreaming v1.17.8
 	github.com/Enflick/smithy-go v1.3.0
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/credentials v1.17.16 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 )

--- a/service/transcribestreaming/internal/testing/go.mod
+++ b/service/transcribestreaming/internal/testing/go.mod
@@ -4,15 +4,15 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/aws/protocol/eventstream v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/service/internal/eventstreamtesting v1.4.3
 	github.com/Enflick/aws-sdk-go-v2/service/transcribestreaming v1.17.8
 	github.com/Enflick/smithy-go v1.3.0
 )
 
 require (
-	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3 // indirect
+	github.com/Enflick/aws-sdk-go-v2/credentials v0.0.0-20250325221836-b4195dfa2eb5 // indirect
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5 // indirect
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3 // indirect
 )
 

--- a/service/transfer/go.mod
+++ b/service/transfer/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 	github.com/jmespath/go-jmespath v0.4.0

--- a/service/translate/go.mod
+++ b/service/translate/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/trustedadvisor/go.mod
+++ b/service/trustedadvisor/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/verifiedpermissions/go.mod
+++ b/service/verifiedpermissions/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/voiceid/go.mod
+++ b/service/voiceid/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/vpclattice/go.mod
+++ b/service/vpclattice/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/waf/go.mod
+++ b/service/waf/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/wafregional/go.mod
+++ b/service/wafregional/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/wafv2/go.mod
+++ b/service/wafv2/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/wellarchitected/go.mod
+++ b/service/wellarchitected/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/wisdom/go.mod
+++ b/service/wisdom/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/workdocs/go.mod
+++ b/service/workdocs/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/worklink/go.mod
+++ b/service/worklink/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/workmail/go.mod
+++ b/service/workmail/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/workmailmessageflow/go.mod
+++ b/service/workmailmessageflow/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/workspaces/go.mod
+++ b/service/workspaces/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/workspacesthinclient/go.mod
+++ b/service/workspacesthinclient/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/workspacesweb/go.mod
+++ b/service/workspacesweb/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )

--- a/service/xray/go.mod
+++ b/service/xray/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Enflick/aws-sdk-go-v2 v1.3.0
-	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325155711-0a4bf6fdbeb3
+	github.com/Enflick/aws-sdk-go-v2/internal/configsources v0.0.0-20250325221836-b4195dfa2eb5
 	github.com/Enflick/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0-20250325155711-0a4bf6fdbeb3
 	github.com/Enflick/smithy-go v1.3.0
 )


### PR DESCRIPTION
I have the ai auto-reply changes building with the current main of this repo, but given an additional Enflick/aws-sdk-go-v2/config import I had to add to main, this will help simplify the go.mod textnow-mono. Basically go mod still tries to pull the initial version before applying the replace directive, and this prevents it from looking for a non-existent version left over from the real aws repo fork.